### PR TITLE
67 update poll transaction function

### DIFF
--- a/src/main/java/org/privacyidea/ChallengeStatus.java
+++ b/src/main/java/org/privacyidea/ChallengeStatus.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 NetKnights GmbH - lukas.matusiewicz@netknights.it
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License here:
+ * <a href="http://www.apache.org/licenses/LICENSE-2.0">License</a>
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.privacyidea;
+
+public enum ChallengeStatus
+{
+    accept, declined, pending, none
+}

--- a/src/main/java/org/privacyidea/JSONParser.java
+++ b/src/main/java/org/privacyidea/JSONParser.java
@@ -174,6 +174,15 @@ public class JSONParser
             response.type = getString(detail, TYPE);
             response.otpLength = getInt(detail, OTPLEN);
 
+            String r = getString(detail, CHALLENGE_STATUS);
+            for (ChallengeStatus en : ChallengeStatus.values())
+            {
+                if (en.toString().equals(r))
+                {
+                    response.challengeStatus = en;
+                }
+            }
+
             JsonArray arrMessages = detail.getAsJsonArray(MESSAGES);
             if (arrMessages != null)
             {

--- a/src/main/java/org/privacyidea/JSONParser.java
+++ b/src/main/java/org/privacyidea/JSONParser.java
@@ -129,11 +129,11 @@ public class JSONParser
         if (result != null)
         {
             String r = getString(result, AUTHENTICATION);
-            for (AuthenticationStatus en : AuthenticationStatus.values())
+            for (AuthenticationStatus as: AuthenticationStatus.values())
             {
-                if (en.toString().equals(r))
+                if (as.toString().equals(r))
                 {
-                    response.authentication = en;
+                    response.authentication = as;
                 }
             }
             response.status = getBoolean(result, STATUS);
@@ -175,11 +175,11 @@ public class JSONParser
             response.otpLength = getInt(detail, OTPLEN);
 
             String r = getString(detail, CHALLENGE_STATUS);
-            for (ChallengeStatus en : ChallengeStatus.values())
+            for (ChallengeStatus cs: ChallengeStatus.values())
             {
-                if (en.toString().equals(r))
+                if (cs.toString().equals(r))
                 {
-                    response.challengeStatus = en;
+                    response.challengeStatus = cs;
                 }
             }
 

--- a/src/main/java/org/privacyidea/PIConstants.java
+++ b/src/main/java/org/privacyidea/PIConstants.java
@@ -50,6 +50,7 @@ public class PIConstants
     public static final String PASSWORD = "password";
     public static final String PASS = "pass";
     public static final String SERIAL = "serial";
+    public static final String CHALLENGE_STATUS = "challenge_status";
     public static final String TYPE = "type";
     public static final String TRANSACTION_ID = "transaction_id";
     public static final String REALM = "realm";

--- a/src/main/java/org/privacyidea/PIResponse.java
+++ b/src/main/java/org/privacyidea/PIResponse.java
@@ -36,6 +36,7 @@ public class PIResponse
     public List<Challenge> multiChallenge = new ArrayList<>();
     public String transactionID = "";
     public String serial = "";
+    public ChallengeStatus challengeStatus = ChallengeStatus.none;
     public String image = "";
     public int id = 0;
     public String jsonRPCVersion = "";

--- a/src/main/java/org/privacyidea/PrivacyIDEA.java
+++ b/src/main/java/org/privacyidea/PrivacyIDEA.java
@@ -239,19 +239,7 @@ public class PrivacyIDEA implements Closeable
         params.put(TRANSACTION_ID, transactionID);
         String response = runRequestAsync(ENDPOINT_POLLTRANSACTION, params, Collections.emptyMap(), false, GET);
         PIResponse piresponse = this.parser.parsePIResponse(response);
-        if (piresponse.challengeStatus == ChallengeStatus.pending)
-        {
-            return ChallengeStatus.pending;
-        }
-        else if (piresponse.challengeStatus == ChallengeStatus.accept)
-        {
-            return ChallengeStatus.accept;
-        }
-        else if (piresponse.challengeStatus == ChallengeStatus.declined)
-        {
-            return ChallengeStatus.declined;
-        }
-        return ChallengeStatus.none;
+        return piresponse.challengeStatus;
     }
 
     /**

--- a/src/main/java/org/privacyidea/PrivacyIDEA.java
+++ b/src/main/java/org/privacyidea/PrivacyIDEA.java
@@ -229,9 +229,9 @@ public class PrivacyIDEA implements Closeable
      * Poll for status of the given transaction ID once.
      *
      * @param transactionID transaction ID to poll for
-     * @return the status value, true or false
+     * @return the challenge status or "ChallengeStatus.none" if error
      */
-    public boolean pollTransaction(String transactionID)
+    public ChallengeStatus pollTransaction(String transactionID)
     {
         Objects.requireNonNull(transactionID, "TransactionID is required!");
 
@@ -239,7 +239,19 @@ public class PrivacyIDEA implements Closeable
         params.put(TRANSACTION_ID, transactionID);
         String response = runRequestAsync(ENDPOINT_POLLTRANSACTION, params, Collections.emptyMap(), false, GET);
         PIResponse piresponse = this.parser.parsePIResponse(response);
-        return piresponse.value;
+        if (piresponse.challengeStatus == ChallengeStatus.pending)
+        {
+            return ChallengeStatus.pending;
+        }
+        else if (piresponse.challengeStatus == ChallengeStatus.accept)
+        {
+            return ChallengeStatus.accept;
+        }
+        else if (piresponse.challengeStatus == ChallengeStatus.declined)
+        {
+            return ChallengeStatus.declined;
+        }
+        return ChallengeStatus.none;
     }
 
     /**

--- a/src/test/java/org/privacyidea/TestPollTransaction.java
+++ b/src/test/java/org/privacyidea/TestPollTransaction.java
@@ -166,9 +166,9 @@ public class TestPollTransaction
                                    .withPath("/validate/polltransaction")
                                    .withQueryStringParameter("transaction_id", "02659936574063359702"), Times.exactly(times))
                   .respond(HttpResponse.response()
-                                       .withBody("{\n\"  id\": 1,\n\"  jsonrpc\": \"2.0\",\n" + challengeStatusParameter +
-                                                 "  \"result\": {\n    \"status\": true\n  },\n  \"time\": 1589446811.1909237,\n  \"version\": \"privacyIDEA 3.2.1\",\n" +
-                                                 "  \"versionnumber\": \"3.2.1\",\n  \"signature\": \"rsa_sha256_pss:\"\n}")
+                                       .withBody("{\n\"id\": 1,\n\"jsonrpc\": \"2.0\",\n" + challengeStatusParameter +
+                                                 "\"result\": {\n\"status\": true\n},\n\"time\": 1589446811.1909237,\n\"version\": \"privacyIDEA 3.2.1\",\n" +
+                                                 "\"versionnumber\": \"3.2.1\",\n\"signature\": \"rsa_sha256_pss:\"\n}")
                                        .withDelay(TimeUnit.MILLISECONDS, 50));
     }
 
@@ -177,21 +177,20 @@ public class TestPollTransaction
         String challengeStatusParameter = "";
         if (challengeStatus == ChallengeStatus.accept)
         {
-            challengeStatusParameter = "  \"detail\": {\n    \"challenge_status\": \"accept\"\n  },\n";
+            challengeStatusParameter = "\"detail\": {\n\"challenge_status\": \"accept\"\n},\n";
         }
         else if (challengeStatus == ChallengeStatus.declined)
         {
-            challengeStatusParameter = "  \"detail\": {\n    \"challenge_status\": \"declined\"\n  },\n";
+            challengeStatusParameter = "\"detail\": {\n\"challenge_status\": \"declined\"\n},\n";
 
         }
         else if (challengeStatus == ChallengeStatus.pending)
         {
-            challengeStatusParameter = "  \"detail\": {\n    \"challenge_status\": \"pending\"\n  },\n";
+            challengeStatusParameter = "\"detail\": {\n\"challenge_status\": \"pending\"\n},\n";
         }
         return challengeStatusParameter;
     }
-
-
+    
     @After
     public void tearDown()
     {


### PR DESCRIPTION
This pull request introduces a new enumeration `ChallengeStatus` to manage the poll transaction challenge status in the `privacyIDEA` project. The changes include updates across multiple files to integrate this new enum and modify the related logic accordingly.

Key changes include:

### New Enumeration
* [`src/main/java/org/privacyidea/ChallengeStatus.java`](diffhunk://#diff-a56b8ea41be8d598710084e8ccfa86a5fdc70f2d424b74d23534055eb5e9f140R1-R20): Added a new enum `ChallengeStatus` with possible values: `accept`, `declined`, `pending`, and `none`.

### Integration of `ChallengeStatus`
* [`src/main/java/org/privacyidea/JSONParser.java`](diffhunk://#diff-dfd1afd5a71fe1f0585172a8d7d31857d59d3d9418cfbe464b96ed4f243f0cb9R177-R185): Updated the parsing logic to set `response.challengeStatus` based on the new `ChallengeStatus` enum.
* [`src/main/java/org/privacyidea/PIConstants.java`](diffhunk://#diff-3110d8340ae3f9cc5532e4004ad2e4afcebf218aa9ba74d8d6281c839b278b66R53): Added a new constant `CHALLENGE_STATUS` to be used as a key for challenge status in JSON responses.
* [`src/main/java/org/privacyidea/PIResponse.java`](diffhunk://#diff-18937acf40a6322a24b14990029ebba1940ccc9629d4a87dab011561159c3f96R39): Added a new field `challengeStatus` of type `ChallengeStatus` initialized to `ChallengeStatus.none`.
* [`src/main/java/org/privacyidea/PrivacyIDEA.java`](diffhunk://#diff-e3dabaaa6aca1cde45fec375fb7a2cc3c7e4ee669fccf8d9bfc6eb0bb05e3223L232-R254): Modified the `pollTransaction` method to return a `ChallengeStatus` instead of a boolean, reflecting the new challenge status values.

### Test Updates
* [`src/test/java/org/privacyidea/TestPollTransaction.java`](diffhunk://#diff-175b2540f103f1ac5c7e586640a8fc52b81c6727265a7fb5a375717918e6d81bL114-R136): Updated test cases to handle the new `ChallengeStatus` values and modified the `setPollTransactionResponse` method to use `ChallengeStatus` instead of boolean values. [[1]](diffhunk://#diff-175b2540f103f1ac5c7e586640a8fc52b81c6727265a7fb5a375717918e6d81bL114-R136) [[2]](diffhunk://#diff-175b2540f103f1ac5c7e586640a8fc52b81c6727265a7fb5a375717918e6d81bL151-R193)
* All known poll transaction scenarios covered with tests.