### PR TITLE
81 add enroll via mc optional

### DIFF
--- a/src/main/java/org/privacyidea/JSONParser.java
+++ b/src/main/java/org/privacyidea/JSONParser.java
@@ -241,6 +241,9 @@ public class JSONParser
             response.transactionID = getString(detail, TRANSACTION_ID);
             response.type = getString(detail, TYPE);
             response.otpLength = getInt(detail, OTPLEN);
+            response.isEnrollViaMultichallenge = getBoolean(detail, "enroll_via_multichallenge");
+            response.isEnrollViaMultichallengeOptional = getBoolean(detail, "enroll_via_multichallenge_optional");
+            // The enrollment link can be in the detail or in one of the
             JsonObject passkeyChallenge = detail.getAsJsonObject(PASSKEY);
             if (passkeyChallenge != null && !passkeyChallenge.isJsonNull())
             {

--- a/src/main/java/org/privacyidea/PIConstants.java
+++ b/src/main/java/org/privacyidea/PIConstants.java
@@ -68,6 +68,7 @@ public class PIConstants
     public static final String CLIENT_MODE = "client_mode";
     public static final String IMAGE = "image";
     public static final String CLIENT_IP = "client";
+    public static final String CANCEL_ENROLLMENT = "cancel_enrollment";
     public static final String MESSAGES = "messages";
     public static final String MULTI_CHALLENGE = "multi_challenge";
     public static final String ATTRIBUTES = "attributes";

--- a/src/main/java/org/privacyidea/PIResponse.java
+++ b/src/main/java/org/privacyidea/PIResponse.java
@@ -18,13 +18,14 @@ package org.privacyidea;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.privacyidea.PIConstants.*;
+import static org.privacyidea.PIConstants.TOKEN_TYPE_PUSH;
+import static org.privacyidea.PIConstants.TOKEN_TYPE_WEBAUTHN;
+
 
 /**
  * This class parses the JSON response of privacyIDEA into a POJO for easier access.
@@ -56,6 +57,9 @@ public class PIResponse
     public String passkeyRegistration = "";
     public String username = "";
     public String enrollmentLink = "";
+    // Enroll via Multichallenge
+    public boolean isEnrollViaMultichallenge = false;
+    public boolean isEnrollViaMultichallengeOptional = false;
 
     public String webAuthnSignRequest = "";
     public String webAuthnTransactionId = "";

--- a/src/main/java/org/privacyidea/PrivacyIDEA.java
+++ b/src/main/java/org/privacyidea/PrivacyIDEA.java
@@ -41,6 +41,7 @@ import static org.privacyidea.PIConstants.ENDPOINT_TOKEN;
 import static org.privacyidea.PIConstants.ENDPOINT_TOKEN_INIT;
 import static org.privacyidea.PIConstants.ENDPOINT_TRIGGERCHALLENGE;
 import static org.privacyidea.PIConstants.ENDPOINT_VALIDATE_CHECK;
+import static org.privacyidea.PIConstants.CANCEL_ENROLLMENT;
 import static org.privacyidea.PIConstants.ENDPOINT_VALIDATE_INITIALIZE;
 import static org.privacyidea.PIConstants.GENKEY;
 import static org.privacyidea.PIConstants.GET;
@@ -371,6 +372,32 @@ public class PrivacyIDEA implements Closeable
         String response = runRequestAsync(ENDPOINT_POLLTRANSACTION, params, Collections.emptyMap(), false, GET);
         PIResponse piresponse = this.parser.parsePIResponse(response);
         return piresponse.challengeStatus;
+    }
+
+    /**
+     * @see PrivacyIDEA#validateCheckCancelEnrollment(String, Map)
+     */
+    public PIResponse validateCheckCancelEnrollment(String transactionID)
+    {
+        return this.validateCheckCancelEnrollment(transactionID, Collections.emptyMap());
+    }
+
+    /**
+     * Cancel enrollment via multichallenge.
+     *
+     * @param transactionID transaction ID
+     * @param headers       optional headers for the request
+     * @return PIResponse or null if error
+     */
+    public PIResponse validateCheckCancelEnrollment(String transactionID, Map<String, String> headers)
+    {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put(TRANSACTION_ID, transactionID);
+        params.put(CANCEL_ENROLLMENT, "true");
+        appendRealm(params);
+
+        String response = runRequestAsync(ENDPOINT_VALIDATE_CHECK, params, headers, false, POST);
+        return this.parser.parsePIResponse(response);
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for handling multi-challenge enrollment flags in the privacyIDEA response parsing logic. The main changes introduce new fields to capture whether enrollment via multi-challenge is required or optional, and update the parsing logic to set these fields when processing interactive responses.

**Multi-challenge enrollment support:**

* Added new boolean fields `isEnrollViaMultichallenge` and `isEnrollViaMultichallengeOptional` to the `PIResponse` class to indicate multi-challenge enrollment requirements.
* Updated the JSON parsing logic in `JSONParser.java` to extract `enroll_via_multichallenge` and `enroll_via_multichallenge_optional` from the response details when in interactive mode.
* Added a new const CANCEL_ENROLLMENT
* Implemented a new function `validateCheckCancelEnrollment` to the `PrivacyIDEA` class.

**Code organization:**

* Refined imports to only include needed constants for token types, improving clarity and maintainability.